### PR TITLE
Bugfix: Do not send multiple responses.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@
 
   monkeypatch( Collection.prototype, 'handle', function(original,ctx){
     if( ctx ) acl.apply( ctx, [ ctx, {} ] )
-    original(ctx)
+    if( !ctx.res.finished ) original(ctx)
   })
 
   monkeypatch( Script.prototype,'run',function(original,ctx,domain,fn){
@@ -129,7 +129,7 @@
        ctx.acl = acl.bind(ctx,ctx)
        acl.apply( ctx, [ ctx, {} ] )
     }
-    original(ctx,domain,fn)
+    if( !ctx.res.finished ) original(ctx,domain,fn)
   })
   
 })(require('deployd/lib/script'), require('deployd/lib/resources/collection'));


### PR DESCRIPTION
When try to restrict the GET Method you will get an Node.js error:
```Can't set headers after they are sent to the client```.
After failing the acl check it will still execute the usual context which results in sending an additional answer.  A simple check if the response is already finished solves this problem.